### PR TITLE
Actions: Re-group build artifacts

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -63,12 +63,29 @@ jobs:
         find . -name .git -prune -o -type f | sort -f
         cp -v */geiss_scr.exe bin_saver/geiss.scr  # for upload
         cp -v */vis_geis.dll bin_plugin/  # for upload and installer
+
         ./makensis_198 installer_PLUGIN.nsi  # writes to bin_plugin/
         find bin_*/ -type f | sort -f
 
-    - name: Upload build artifacts
+        mv bin_plugin/geiss4winamp_429.exe ./  # i.e. out of bin_plugin/
+
+    - name: Upload screensaver binary
       uses: actions/upload-artifact@v3.1.2
       with:
-        name: geiss_win32bin
-        path: bin_*/*
+        name: "geiss_saver_429_${{ github.sha }}"
+        path: "bin_saver/*"
+        if-no-files-found: error
+
+    - name: Upload plug-in binary
+      uses: actions/upload-artifact@v3.1.2
+      with:
+        name: "geiss4winamp_429_${{ github.sha }}"
+        path: "bin_plugin/*"
+        if-no-files-found: error
+
+    - name: Upload plug-in installer
+      uses: actions/upload-artifact@v3.1.2
+      with:
+        name: "geiss4winamp_429_installer_${{ github.sha }}"
+        path: "geiss4winamp_429.exe"
         if-no-files-found: error


### PR DESCRIPTION
Before:
- `geiss_win32bin.zip` — 2x plain binaries + installer

After:
- `geiss_saver_429_${GITHUB_SHA}.zip` — plain binaries
- `geiss4winamp_429_${GITHUB_SHA}.zip` — plain binaries
- `geiss4winamp_429_installer_${GITHUB_SHA}.zip` — installer

What it looks like:
![artefacts_Screenshot_20230115_034419](https://user-images.githubusercontent.com/1577132/212520276-4a02cd87-de72-4de9-9a48-fd3d822b4609.png)
