### PR TITLE
Pin GitHub Actions to specific commits for security

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: windows-2022
     steps:
 
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
     - name: Configure build
       run: |-
@@ -70,21 +70,21 @@ jobs:
         mv bin_plugin/geiss4winamp_430.exe ./  # i.e. out of bin_plugin/
 
     - name: Upload screensaver binary
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: "geiss_saver_430_${{ github.sha }}"
         path: "bin_saver/*"
         if-no-files-found: error
 
     - name: Upload plug-in binary
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: "geiss4winamp_430_${{ github.sha }}"
         path: "bin_plugin/*"
         if-no-files-found: error
 
     - name: Upload plug-in installer
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: "geiss4winamp_430_installer_${{ github.sha }}"
         path: "geiss4winamp_430.exe"


### PR DESCRIPTION
For proof that GitHub Dependabot can still keep things up to date for us with the new format see https://github.com/gentoo-ev/www.gentoo-ev.org/pull/5/files .